### PR TITLE
DCMAW-8008: Change retrieve methods to return `RetrievalEvent`

### DIFF
--- a/.github/conventional_commit_template.txt
+++ b/.github/conventional_commit_template.txt
@@ -6,6 +6,7 @@
 # Reference JIRA tickets here:
 # Resolves: DCMAW-000, GOVAPP-000
 
+
 # Uncomment below line to include details of any breaking changes
 # BREAKING CHANGES:
 

--- a/app/src/androidTest/java/uk/gov/android/securestore/SharedPrefsStoreInstrumentationTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/securestore/SharedPrefsStoreInstrumentationTest.kt
@@ -6,7 +6,6 @@ import java.security.KeyStore
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -23,6 +22,7 @@ import uk.gov.android.securestore.authentication.Authenticator
 import uk.gov.android.securestore.authentication.AuthenticatorCallbackHandler
 import uk.gov.android.securestore.authentication.AuthenticatorPromptConfiguration
 import uk.gov.android.securestore.error.SecureStorageError
+import uk.gov.android.securestore.error.SecureStoreErrorType
 
 @RunWith(AndroidJUnit4::class)
 class SharedPrefsStoreInstrumentationTest {
@@ -56,7 +56,7 @@ class SharedPrefsStoreInstrumentationTest {
                 val result = sharedPrefsStore.retrieve(
                     key
                 )
-                assertEquals(value, result)
+                assertEquals(RetrievalEvent.Success(value), result)
             }
         }
     }
@@ -107,7 +107,10 @@ class SharedPrefsStoreInstrumentationTest {
                 val result = sharedPrefsStore.retrieve(
                     key
                 )
-                assertNull(result)
+                assertEquals(
+                    RetrievalEvent.Failed(SecureStoreErrorType.GENERAL),
+                    result
+                )
             }
         }
     }

--- a/app/src/main/java/uk/gov/android/securestore/RetrievalEvent.kt
+++ b/app/src/main/java/uk/gov/android/securestore/RetrievalEvent.kt
@@ -1,0 +1,23 @@
+package uk.gov.android.securestore
+
+import uk.gov.android.securestore.error.SecureStoreErrorType
+
+/**
+ * Class to handle the return events when getting data from a [SecureStore]
+ */
+sealed class RetrievalEvent {
+    /**
+     * Successful event, holds the retrieved data value as a [String]
+     */
+    data class Success(
+        val value: String
+    ) : RetrievalEvent()
+
+    /**
+     * Failure event, holds the type of failure as [SecureStoreErrorType] and an optional reason
+     */
+    data class Failed(
+        val type: SecureStoreErrorType,
+        val reason: String? = null
+    ) : RetrievalEvent()
+}

--- a/app/src/main/java/uk/gov/android/securestore/SecureStore.kt
+++ b/app/src/main/java/uk/gov/android/securestore/SecureStore.kt
@@ -2,6 +2,7 @@ package uk.gov.android.securestore
 
 import android.content.Context
 import androidx.fragment.app.FragmentActivity
+import kotlinx.coroutines.flow.Flow
 import uk.gov.android.securestore.authentication.AuthenticatorPromptConfiguration
 
 /**
@@ -44,29 +45,27 @@ interface SecureStore {
      * Access the data for a given key when authentication is not required; access control level is set to OPEN
      *
      * @param [key] The unique key to identify data to retrieve
-     * @return The data held against the given key, null if no data held
+     * @return [RetrievalEvent] to cover success or failure
      *
-     * @throws [SecureStorageError] if unable to retrieve
      */
     suspend fun retrieve(
         key: String
-    ): String?
+    ): RetrievalEvent
 
     /**
      * Access the data for a given key when authentication is required; access control level is not OPEN
      *
      * @param [key] The unique key to identify data to retrieve
-     * @param authPromptConfig Configuration for the Biometric prompt
+     * @param [authPromptConfig] Configuration for the Biometric prompt
      * @param [context] The [FragmentActivity] where the method is called, used for auth prompt
-     * @return The data held against the given key, null if no data held
+     * @return A [Flow] of [RetrievalEvent]s, allowing for multiple failed attempts for auth
      *
-     * @throws [SecureStorageError] if unable to retrieve
      */
     suspend fun retrieveWithAuthentication(
         key: String,
         authPromptConfig: AuthenticatorPromptConfiguration,
         context: FragmentActivity
-    ): String?
+    ): Flow<RetrievalEvent>
 
     /**
      * Check if a certain key exists in the store

--- a/app/src/main/java/uk/gov/android/securestore/error/SecureStorageError.kt
+++ b/app/src/main/java/uk/gov/android/securestore/error/SecureStorageError.kt
@@ -7,5 +7,6 @@ class SecureStorageError(
 
 enum class SecureStoreErrorType {
     GENERAL,
-    USER_CANCELED_BIO_PROMPT
+    USER_CANCELED_BIO_PROMPT,
+    FAILED_BIO_PROMPT
 }


### PR DESCRIPTION
- Retrieve now returns `RetrivalEvent`
- RetrieveWithAuth now returns a `Flow<RetrievalEvent>`, this allows mutiple errors to be passed back and handled
- RetrievalEvent has also reduced the reliance on throwing `SecureStroageErrors` and makes general error handling much cleaner Resolves: DCMAW-8008

BREAKING CHANGES: Returns types of `retrieve` and `retrieveWithAuthentication` are now `RetrievalEvent` and `Flow<RetrievalEvent` respectively. This massively improves error handling and multiple events from BiometricPrompt when doing auth