### PR TITLE
chore: updated dependabot commit format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "build"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Updated Dependabot commit format to use conventional commits.
This file has been copied from the [mobile-android-logging](https://github.com/govuk-one-login/mobile-android-logging/blob/main/.github/dependabot.yml) repository.