### PR TITLE
feat!: Remove need for activity in upsert and delete methods

### DIFF
--- a/app/src/androidTest/java/uk/gov/android/securestore/SharedPrefsStoreInstrumentationTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/securestore/SharedPrefsStoreInstrumentationTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.android.securestore
 
 import androidx.test.ext.junit.rules.ActivityScenarioRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.security.KeyStore
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -12,7 +11,6 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
@@ -51,7 +49,7 @@ class SharedPrefsStoreInstrumentationTest {
         initSecureStore(AccessControlLevel.OPEN)
         rule.scenario.onActivity {
             runBlocking {
-                sharedPrefsStore.upsert(key, value, it)
+                sharedPrefsStore.upsert(key, value)
                 val result = sharedPrefsStore.retrieve(
                     key
                 )
@@ -76,7 +74,7 @@ class SharedPrefsStoreInstrumentationTest {
 
         rule.scenario.onActivity {
             runBlocking {
-                sharedPrefsStore.upsert(key, value, it)
+                sharedPrefsStore.upsert(key, value)
                 assertThrows(SecureStorageError::class.java) {
                     runBlocking {
                         val result = sharedPrefsStore.retrieveWithAuthentication(
@@ -100,9 +98,9 @@ class SharedPrefsStoreInstrumentationTest {
         initSecureStore(AccessControlLevel.OPEN)
         rule.scenario.onActivity {
             runBlocking {
-                sharedPrefsStore.upsert(key, value, it)
+                sharedPrefsStore.upsert(key, value)
 
-                sharedPrefsStore.delete(key, it)
+                sharedPrefsStore.delete(key)
                 val result = sharedPrefsStore.retrieve(
                     key
                 )
@@ -119,7 +117,7 @@ class SharedPrefsStoreInstrumentationTest {
         initSecureStore(AccessControlLevel.OPEN)
         rule.scenario.onActivity {
             runBlocking {
-                sharedPrefsStore.upsert(key, value, it)
+                sharedPrefsStore.upsert(key, value)
 
                 val result = sharedPrefsStore.exists(key)
 

--- a/app/src/androidTest/java/uk/gov/android/securestore/authentication/UserAuthenticatorTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/securestore/authentication/UserAuthenticatorTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.android.securestore.authentication
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import uk.gov.android.securestore.AccessControlLevel
+import uk.gov.android.securestore.TestActivity
+
+class UserAuthenticatorTest {
+    @JvmField
+    @Rule
+    val rule: ActivityScenarioRule<TestActivity> = ActivityScenarioRule(TestActivity::class.java)
+
+    private val authenticator: Authenticator = UserAuthenticator()
+    private val authConfig = AuthenticatorPromptConfiguration(
+        "title",
+        "sub title",
+        "description"
+    )
+
+    @Test
+    fun openAuthFails() {
+        rule.scenario.onActivity {
+            authenticator.init(it)
+
+            assertThrows(IllegalArgumentException::class.java) {
+                authenticator.authenticate(
+                    AccessControlLevel.OPEN,
+                    authConfig,
+                    AuthenticatorCallbackHandler()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun runPasscodeCheck() {
+        rule.scenario.onActivity {
+            authenticator.init(it)
+
+            authenticator.authenticate(
+                AccessControlLevel.PASSCODE,
+                authConfig,
+                AuthenticatorCallbackHandler()
+            )
+        }
+    }
+}

--- a/app/src/main/java/uk/gov/android/securestore/SecureStore.kt
+++ b/app/src/main/java/uk/gov/android/securestore/SecureStore.kt
@@ -25,21 +25,19 @@ interface SecureStore {
      *
      * @param [key] The unique key to save the data against
      * @param [value] The data to save as a [String]
-     * @param [context] The [FragmentActivity] where the method is called
      *
-     * @throws [SecureStorageError] if unable to save
+     * @throws [uk.gov.android.securestore.error.SecureStorageError] if unable to save
      */
-    suspend fun upsert(key: String, value: String, context: FragmentActivity): String
+    suspend fun upsert(key: String, value: String): String
 
     /**
      * Delete a given value based on a key
      *
      * @param [key] The unique identifier for the value to delete
-     * @param [context] The [FragmentActivity] where the method is called
      *
-     * @throws [SecureStorageError] if unable to delete
+     * @throws [uk.gov.android.securestore.error.SecureStorageError] if unable to delete
      */
-    fun delete(key: String, context: FragmentActivity)
+    fun delete(key: String)
 
     /**
      * Access the data for a given key when authentication is not required; access control level is set to OPEN
@@ -73,7 +71,7 @@ interface SecureStore {
      * @param [key] Key to select
      * @return True or false if the key exists in the store
      *
-     * @throws [SecureStorageError] if unable to check for existence
+     * @throws [uk.gov.android.securestore.error.SecureStorageError] if unable to check for existence
      */
     fun exists(key: String): Boolean
 }

--- a/app/src/main/java/uk/gov/android/securestore/SharedPrefsStore.kt
+++ b/app/src/main/java/uk/gov/android/securestore/SharedPrefsStore.kt
@@ -41,30 +41,24 @@ class SharedPrefsStore(
         sharedPrefs = context.getSharedPreferences(configuration.id, Context.MODE_PRIVATE)
     }
 
-    override suspend fun upsert(key: String, value: String, context: FragmentActivity): String {
+    override suspend fun upsert(key: String, value: String): String {
         return suspendCoroutine { continuation ->
             try {
-                authenticator.init(context)
                 val result = cryptoManager.encryptText(value)
                     .also { writeToPrefs(key, it) }
                 continuation.resumeWith(Result.success(result))
             } catch (e: Exception) {
                 throw SecureStorageError(e)
-            } finally {
-                authenticator.close()
             }
         }
     }
 
-    override fun delete(key: String, context: FragmentActivity) {
+    override fun delete(key: String) {
         writeToPrefs(key, null)
         try {
-            authenticator.init(context)
             cryptoManager.deleteKey()
         } catch (e: Exception) {
             throw SecureStorageError(e)
-        } finally {
-            authenticator.close()
         }
     }
 

--- a/app/src/test/java/uk/gov/android/securestore/SharedPrefsStoreTest.kt
+++ b/app/src/test/java/uk/gov/android/securestore/SharedPrefsStoreTest.kt
@@ -61,7 +61,7 @@ class SharedPrefsStoreTest {
         whenever(mockCryptoManager.encryptText(value)).thenReturn(encryptedValue)
 
         runBlocking {
-            sharedPrefsStore.upsert(key, value, activityFragment)
+            sharedPrefsStore.upsert(key, value)
 
             verify(mockCryptoManager).encryptText(value)
             verify(mockEditor).putString(key, encryptedValue)
@@ -72,7 +72,7 @@ class SharedPrefsStoreTest {
     @Test
     fun testDelete() {
         initSecureStore(AccessControlLevel.OPEN)
-        sharedPrefsStore.delete(key, activityFragment)
+        sharedPrefsStore.delete(key)
 
         verify(mockEditor).putString(key, null)
         verify(mockEditor).apply()
@@ -175,7 +175,7 @@ class SharedPrefsStoreTest {
 
         assertThrows(SecureStorageError::class.java) {
             runBlocking {
-                sharedPrefsStore.upsert(key, value, activityFragment)
+                sharedPrefsStore.upsert(key, value)
             }
         }
     }
@@ -241,7 +241,7 @@ class SharedPrefsStoreTest {
         initSecureStore(AccessControlLevel.OPEN)
         given(mockCryptoManager.deleteKey()).willAnswer { throw KeyStoreException() }
         assertThrows(SecureStorageError::class.java) {
-            sharedPrefsStore.delete(key, activityFragment)
+            sharedPrefsStore.delete(key)
         }
     }
 
@@ -249,7 +249,7 @@ class SharedPrefsStoreTest {
     fun testUpsertThrowsIfNotInit() {
         assertThrows(SecureStorageError::class.java) {
             runBlocking {
-                sharedPrefsStore.upsert(key, value, activityFragment)
+                sharedPrefsStore.upsert(key, value)
             }
         }
     }
@@ -299,7 +299,7 @@ class SharedPrefsStoreTest {
     fun testDeleteThrowsIfNotInit() {
         assertThrows(SecureStorageError::class.java) {
             runBlocking {
-                sharedPrefsStore.delete(key, activityFragment)
+                sharedPrefsStore.delete(key)
             }
         }
     }


### PR DESCRIPTION
- remove need for activity in upsert and delete methods
- also include some tests for `UserAuthenticator`

Resolves: DCMAW-9394
BREAKING CHANGES: removing activity from method arguments for `upsert` and `delete`