### PR TITLE
build: Revert AGP upgrade to test coverage

### DIFF
--- a/config/android/lint.xml
+++ b/config/android/lint.xml
@@ -12,5 +12,6 @@
     </issue>
 
     <issue id="SyntheticAccessor" severity="ignore"/>
+    <issue id="NewerVersionAvailable" severity="ignore" />
 </lint>
 

--- a/config/android/lint.xml
+++ b/config/android/lint.xml
@@ -12,6 +12,6 @@
     </issue>
 
     <issue id="SyntheticAccessor" severity="ignore"/>
-    <issue id="NewerVersionAvailable" severity="ignore" />
+    <issue id="AndroidGradlePluginVersion" severity="ignore" />
 </lint>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-android-gradle = "8.8.0" # https://developer.android.com/studio/releases/gradle-plugin
+android-gradle = "8.7.3" # https://developer.android.com/studio/releases/gradle-plugin
 androidx-test = "1.6.1"
 androidx-junit = "1.2.1"
 appcompat = "1.7.0" # https://developer.android.com/jetpack/androidx/releases/appcompat


### PR DESCRIPTION
Downgrade `AGP` (Android Gradle Plugin) to 8.7.3 to see if the test coverage reverts to over 80% - the new test coverage shows 2 files (interface and internal class) that should be ignored and/or are covered into the `SharedPrefsStore`