### PR TITLE
refactor: stop delete method from throwing exception

### DIFF
--- a/app/src/androidTest/java/uk/gov/android/securestore/SharedPrefsStoreInstrumentationTest.kt
+++ b/app/src/androidTest/java/uk/gov/android/securestore/SharedPrefsStoreInstrumentationTest.kt
@@ -94,7 +94,7 @@ class SharedPrefsStoreInstrumentationTest {
     }
 
     @Test
-    fun testDeleteAndRetrieveNonExistentKey() {
+    fun testDeleteAndRetrieveNonExistentKeyAfterInit() {
         initSecureStore(AccessControlLevel.OPEN)
         rule.scenario.onActivity {
             runBlocking {

--- a/app/src/main/java/uk/gov/android/securestore/SecureStore.kt
+++ b/app/src/main/java/uk/gov/android/securestore/SecureStore.kt
@@ -35,7 +35,6 @@ interface SecureStore {
      *
      * @param [key] The unique identifier for the value to delete
      *
-     * @throws [uk.gov.android.securestore.error.SecureStorageError] if unable to delete
      */
     fun delete(key: String)
 

--- a/app/src/main/java/uk/gov/android/securestore/SharedPrefsStore.kt
+++ b/app/src/main/java/uk/gov/android/securestore/SharedPrefsStore.kt
@@ -55,11 +55,11 @@ class SharedPrefsStore(
     }
 
     override fun delete(key: String) {
-        writeToPrefs(key, null)
-        try {
-            hybridCryptoManager.deleteKey()
-        } catch (e: Exception) {
-            throw SecureStorageError(e)
+        sharedPrefs?.let {
+            with(it.edit()) {
+                remove(key)
+                apply()
+            }
         }
     }
 

--- a/app/src/test/java/uk/gov/android/securestore/SharedPrefsStoreTest.kt
+++ b/app/src/test/java/uk/gov/android/securestore/SharedPrefsStoreTest.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.android.securestore.authentication.Authenticator
 import uk.gov.android.securestore.authentication.AuthenticatorCallbackHandler
@@ -22,7 +23,6 @@ import uk.gov.android.securestore.crypto.HybridCryptoManager
 import uk.gov.android.securestore.error.SecureStorageError
 import uk.gov.android.securestore.error.SecureStoreErrorType
 import java.security.GeneralSecurityException
-import java.security.KeyStoreException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -79,12 +79,19 @@ class SharedPrefsStoreTest {
     }
 
     @Test
-    fun testDelete() {
+    fun testDeleteAfterInit() {
         initSecureStore(AccessControlLevel.OPEN)
         sharedPrefsStore.delete(alias)
 
-        verify(mockEditor).putString(alias, null)
+        verify(mockEditor).remove(alias)
         verify(mockEditor).apply()
+    }
+
+    @Test
+    fun testDeleteNoInit() {
+        sharedPrefsStore.delete(alias)
+
+        verifyNoInteractions(mockEditor)
     }
 
     @Test
@@ -373,15 +380,6 @@ class SharedPrefsStoreTest {
     }
 
     @Test
-    fun testDeleteThrowsError() {
-        initSecureStore(AccessControlLevel.OPEN)
-        given(mockHybridCryptoManager.deleteKey()).willAnswer { throw KeyStoreException() }
-        assertThrows(SecureStorageError::class.java) {
-            sharedPrefsStore.delete(alias)
-        }
-    }
-
-    @Test
     fun testUpsertThrowsIfNotInit() {
         assertThrows(SecureStorageError::class.java) {
             runBlocking {
@@ -430,15 +428,6 @@ class SharedPrefsStoreTest {
         assertThrows(SecureStorageError::class.java) {
             runBlocking {
                 sharedPrefsStore.exists(alias)
-            }
-        }
-    }
-
-    @Test
-    fun testDeleteThrowsIfNotInit() {
-        assertThrows(SecureStorageError::class.java) {
-            runBlocking {
-                sharedPrefsStore.delete(alias)
             }
         }
     }


### PR DESCRIPTION
- Stop delete method from throwing exception
- Also doesn't delete key pair anymore