### PR TITLE
feat: remove return for onFailure bio prompt

### DIFF
--- a/app/src/main/java/uk/gov/android/securestore/SharedPrefsStore.kt
+++ b/app/src/main/java/uk/gov/android/securestore/SharedPrefsStore.kt
@@ -133,12 +133,7 @@ class SharedPrefsStore(
                                 )
                             },
                             onFailure = {
-                                continuation.resume(
-                                    RetrievalEvent.Failed(
-                                        SecureStoreErrorType.FAILED_BIO_PROMPT,
-                                        "Bio Prompt failed",
-                                    ),
-                                )
+                                Log.e(tag, "Bio Prompt Failed")
                             },
                         ),
                     )

--- a/app/src/test/java/uk/gov/android/securestore/SharedPrefsStoreTest.kt
+++ b/app/src/test/java/uk/gov/android/securestore/SharedPrefsStoreTest.kt
@@ -317,39 +317,6 @@ class SharedPrefsStoreTest {
     }
 
     @Test
-    fun testRetrieveWithAuthenticationAuthFails() {
-        initSecureStore(AccessControlLevel.PASSCODE_AND_BIOMETRICS)
-
-        runBlocking {
-            whenever(
-                mockAuthenticator.authenticate(
-                    eq(AccessControlLevel.PASSCODE_AND_BIOMETRICS),
-                    eq(authConfig),
-                    any(),
-                ),
-            ).thenAnswer {
-                (it.arguments[2] as AuthenticatorCallbackHandler).onFailure()
-            }
-
-            val result = sharedPrefsStore.retrieveWithAuthentication(
-                alias,
-                authPromptConfig = authConfig,
-                context = activityFragment,
-            )
-
-            assertEquals(
-                RetrievalEvent.Failed(
-                    SecureStoreErrorType.FAILED_BIO_PROMPT,
-                    "Bio Prompt failed",
-                ),
-                result,
-            )
-            verify(mockAuthenticator).init(activityFragment)
-            verify(mockAuthenticator).close()
-        }
-    }
-
-    @Test
     fun testRetrieveWithAuthenticationAuthErrorsGeneral() {
         initSecureStore(AccessControlLevel.PASSCODE_AND_BIOMETRICS)
 


### PR DESCRIPTION
Fixing a bug where a Biometric prompt failure would finish the coroutine but actually the prompt context continues. Instead now we just log the failure and allow the coroutine to keep running