### PR TITLE
feat: make sure IV is freshly generated every time

### DIFF
--- a/app/src/main/java/uk/gov/android/securestore/crypto/limitedmanager/AesCryptoManager.kt
+++ b/app/src/main/java/uk/gov/android/securestore/crypto/limitedmanager/AesCryptoManager.kt
@@ -20,9 +20,16 @@ class AesCryptoManager : SymmetricCryptoManager {
         // Create and initialize the Cipher
         val cipher = Cipher.getInstance(AES_ALG)
         val aesKey = createKey()
+        val iv = ByteArray(IV_BYTES_SIZE)
+        SecureRandom().nextBytes(iv)
+        val gcmSpec = GCMParameterSpec(TAG_LENGTH, iv)
         cipher.init(
             Cipher.ENCRYPT_MODE,
-            SecretKeySpec(aesKey.encoded, KeyProperties.KEY_ALGORITHM_AES),
+            SecretKeySpec(
+                aesKey.encoded,
+                KeyProperties.KEY_ALGORITHM_AES,
+            ),
+            gcmSpec,
         )
 
         val encryptedKey = encryptAesKey(aesKey.encoded)


### PR DESCRIPTION
### [DCMAW-14425](https://govukverify.atlassian.net/browse/DCMAW-14425)

- Ensure IV is generated fresh every time an AES key is generated
- I believe this was already happening but this makes it explicit
- As detailed [here](https://developer.android.com/reference/javax/crypto/Cipher) it does suggest that using GCM a new IV should be generated each time